### PR TITLE
[RIKU-11] fix : 메인 탭 마지막 상태 유지 구현

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -34,9 +34,30 @@ import RecordPage from '../components/RecordPage';
 import CreateAccountPage from '@pages/CreateAccountPage';
 import { CreateAccountProvider } from '@features/auth/context/CreateAccountProvider'; // 회원가입 페이지에 대한 Provider
 
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { setTabHistory } from '@shared/utils/tabHistory';
+
+function RouteTracker() {
+  const location = useLocation();
+
+  useEffect(() => {
+    const homeTabPrefixes = ['/flash', '/regular', '/training', '/event'];
+
+    const isHomeRelevant = homeTabPrefixes.some((prefix) => location.pathname.includes(prefix));
+
+    if (isHomeRelevant) {
+      setTabHistory('home', location.pathname);
+    }
+  }, [location.pathname]);
+
+  return null; // 화면에 아무것도 안 그림
+}
+
 function App() {
   return (
     <Router>
+      <RouteTracker />
       <div className="min-w-{375px} max-w-full font-AppleSDGothicNeo overflow-y-auto">
         <Routes>
           <Route path="/" element={<OnbordingPage />} />

--- a/src/assets/EditableAttendanceList.tsx
+++ b/src/assets/EditableAttendanceList.tsx
@@ -40,7 +40,7 @@ const EditableAttendanceList: React.FC<EditableAttendanceListProps> = ({
   };
 
   const handleSave = async () => {
-    const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+    const token = localStorage.getItem('accessToken') || 'null';
 
     // status를 확실하게 명시해줘야 타입 에러 방지됨
     const payload = users.map((user) => ({

--- a/src/components/AdminPage/AdminPage.tsx
+++ b/src/components/AdminPage/AdminPage.tsx
@@ -32,7 +32,7 @@ function AdminPage() {
 
   //회원 정보 불러올 함수 fetchMembers()
   async function fetchMembers() {
-    const accessToken = JSON.parse(localStorage.getItem('accessToken') || ''); //localStorage에 저장된 accessToken 값이 없으면 ''으로 초기화
+    const accessToken = localStorage.getItem('accessToken') || ''; //localStorage에 저장된 accessToken 값이 없으면 ''으로 초기화
     const url = '/admin';
 
     try {
@@ -158,7 +158,7 @@ function AdminPage() {
   //저장하는 프로세스를 핸들링하는 메소드 handleSave
   async function handleSave() {
     try {
-      const accessToken = JSON.parse(localStorage.getItem('accessToken') || ''); //localStorage에 저장된 accessToken 값이 없으면 ''으로 초기화
+      const accessToken = localStorage.getItem('accessToken') || ''; //localStorage에 저장된 accessToken 값이 없으면 ''으로 초기화
       const url = '/admin';
       //roleChangedMembers 배열의 요소들에서 studentId, userName만을 추출
       const payload = roleChangedMembers.map(({ studentId, userRole, isPacer }) => ({

--- a/src/components/FlashRun/EditableAttendanceList.tsx
+++ b/src/components/FlashRun/EditableAttendanceList.tsx
@@ -48,7 +48,7 @@ const EditableAttendanceList: React.FC<EditableAttendanceListProps> = ({
   };
 
   const handleSave = async () => {
-    const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+    const token = localStorage.getItem('accessToken') || 'null';
 
     // 서버에 보낼 payload (종료 전/후 동일)
     const payload = users.map((user) => ({

--- a/src/components/FlashRun/FlashRunAdmin.tsx
+++ b/src/components/FlashRun/FlashRunAdmin.tsx
@@ -74,7 +74,7 @@ const FlashRunAdmin: React.FC<FlashRunAdminData> = ({
     if (!code) {
       try {
         // 출석 코드 생성 API 호출
-        const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+        const token = localStorage.getItem('accessToken') || 'null';
         const response = await customAxios.post(
           `/run/flash/post/${postId}/code`,
           {},
@@ -109,7 +109,7 @@ const FlashRunAdmin: React.FC<FlashRunAdminData> = ({
     if (!code) return;
 
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
 
       // 출석 데이터 준비
       const attendanceData = editableParticipants.map((user) => ({
@@ -155,7 +155,7 @@ const FlashRunAdmin: React.FC<FlashRunAdminData> = ({
 
   const handleTabChange = async (tab: '소개' | '명단') => {
     setActiveTab(tab);
-    const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+    const token = localStorage.getItem('accessToken') || 'null';
 
     try {
       const response = await customAxios.get(`/run/flash/post/${postId}`, {
@@ -237,7 +237,7 @@ const FlashRunAdmin: React.FC<FlashRunAdminData> = ({
   useEffect(() => {
     const fetchPostData = async () => {
       try {
-        const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+        const token = localStorage.getItem('accessToken') || 'null';
         const response = await customAxios.get(`/run/flash/post/${postId}`, {
           headers: { Authorization: `${token}` },
         });
@@ -309,7 +309,7 @@ const FlashRunAdmin: React.FC<FlashRunAdminData> = ({
 
   const refetchPost = async () => {
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const { data } = await customAxios.get(`/run/flash/post/${postId}`, {
         headers: { Authorization: `${token}` },
       });
@@ -404,7 +404,7 @@ const FlashRunAdmin: React.FC<FlashRunAdminData> = ({
                       if (!confirmCancel) return;
 
                       try {
-                        const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+                        const token = localStorage.getItem('accessToken') || 'null';
                         if (!token) {
                           alert('로그인이 필요합니다.');
                           return;
@@ -447,7 +447,7 @@ const FlashRunAdmin: React.FC<FlashRunAdminData> = ({
                     if (!confirmDelete) return;
 
                     try {
-                      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+                      const token = localStorage.getItem('accessToken') || 'null';
                       if (!token) {
                         alert('로그인이 필요합니다.');
                         return;

--- a/src/components/FlashRun/FlashRunDetail.tsx
+++ b/src/components/FlashRun/FlashRunDetail.tsx
@@ -33,7 +33,7 @@ const FlashRunDetail: React.FC = () => {
   useEffect(() => {
     const fetchDetail = async () => {
       try {
-        const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+        const token = localStorage.getItem('accessToken') || 'null';
         const response = await customAxios.get(`/run/flash/post/${postId}`, {
           headers: {
             Authorization: `${token}`,

--- a/src/components/FlashRun/FlashRunEdit.tsx
+++ b/src/components/FlashRun/FlashRunEdit.tsx
@@ -26,7 +26,7 @@ function FlashRunEdit() {
 
   useEffect(() => {
     const fetchPost = async () => {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const res = await customAxios.get(`/run/flash/post/${postId}`, {
         headers: { Authorization: `${token}` },
       });
@@ -165,7 +165,7 @@ function FlashRunEdit() {
       const pad = (n: number) => n.toString().padStart(2, '0');
       const eventDateTime = `${utcDate.getFullYear()}-${pad(utcDate.getMonth() + 1)}-${pad(utcDate.getDate())}T${pad(utcDate.getHours())}:${pad(utcDate.getMinutes())}:${pad(utcDate.getSeconds())}`;
 
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const formData = new FormData();
 
       if (title) formData.append('title', title);

--- a/src/components/FlashRun/FlashRunMake.tsx
+++ b/src/components/FlashRun/FlashRunMake.tsx
@@ -120,7 +120,7 @@ function FlashRunMake() {
       console.log('KST 조립된 시간:', kstDate.toString());
       console.log('변환된 UTC:', eventDateTime);
 
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
 
       const formData = new FormData();
       formData.append('title', title);

--- a/src/components/FlashRun/FlashRunUser.tsx
+++ b/src/components/FlashRun/FlashRunUser.tsx
@@ -67,7 +67,7 @@ const FlashRunUser: React.FC<FlashRunUserData> = ({
 
   const handleStartClick = async () => {
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const response = await customAxios.patch(
         `/run/flash/post/${postId}/join`,
         {},
@@ -102,7 +102,7 @@ const FlashRunUser: React.FC<FlashRunUserData> = ({
     }
 
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const response = await customAxios.post(
         `/run/flash/post/${postId}/attend`, // attend 엔드포인트로 변경
         { code },
@@ -130,7 +130,7 @@ const FlashRunUser: React.FC<FlashRunUserData> = ({
 
   const handleTabChange = async (tab: '소개' | '명단') => {
     setActiveTab(tab);
-    const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+    const token = localStorage.getItem('accessToken') || 'null';
 
     try {
       const response = await customAxios.get(`/run/flash/post/${postId}`, {
@@ -190,7 +190,7 @@ const FlashRunUser: React.FC<FlashRunUserData> = ({
   useEffect(() => {
     const fetchPostData = async () => {
       try {
-        const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+        const token = localStorage.getItem('accessToken') || 'null';
         const response = await customAxios.get(`/run/flash/post/${postId}`, {
           headers: { Authorization: `${token}` },
         });
@@ -260,7 +260,7 @@ const FlashRunUser: React.FC<FlashRunUserData> = ({
 
   const handleCancelParticipation = async () => {
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const response = await customAxios.patch(
         `/run/flash/post/${postId}/join`,
         {},
@@ -304,7 +304,7 @@ const FlashRunUser: React.FC<FlashRunUserData> = ({
 
   const refetchPost = async () => {
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const { data } = await customAxios.get(`/run/flash/post/${postId}`, {
         headers: { Authorization: `${token}` },
       });
@@ -364,7 +364,7 @@ const FlashRunUser: React.FC<FlashRunUserData> = ({
                 );
                 if (!ok) return;
                 try {
-                  const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+                  const token = localStorage.getItem('accessToken') || 'null';
                   if (!token) {
                     alert('로그인이 필요합니다.');
                     return;

--- a/src/components/NewEvent/EditableAttendanceList.tsx
+++ b/src/components/NewEvent/EditableAttendanceList.tsx
@@ -58,7 +58,7 @@ const EditableAttendanceList = forwardRef<
     };
 
     const handleSave = async () => {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
 
       const payload = users.map((u) => ({
         userId: u.userId,

--- a/src/components/NewEvent/EventEdit.tsx
+++ b/src/components/NewEvent/EventEdit.tsx
@@ -64,7 +64,7 @@ function EventEdit() {
   useEffect(() => {
     const fetchEventData = async () => {
       try {
-        const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+        const token = localStorage.getItem('accessToken') || 'null';
         const response = await customAxios.get(`/run/event/post/${postId}`, {
           headers: { Authorization: `${token}` },
         });
@@ -119,7 +119,7 @@ function EventEdit() {
       const pad = (n: number) => n.toString().padStart(2, '0');
       const eventDateTime = `${utcDate.getFullYear()}-${pad(utcDate.getMonth() + 1)}-${pad(utcDate.getDate())}T${pad(utcDate.getHours())}:${pad(utcDate.getMinutes())}:${pad(utcDate.getSeconds())}`;
 
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const formData = new FormData();
 
       // 변경된 필드만 추가

--- a/src/components/NewEvent/EventMake.tsx
+++ b/src/components/NewEvent/EventMake.tsx
@@ -56,7 +56,7 @@ function EventMake() {
   useEffect(() => {
     const fetchPacers = async () => {
       try {
-        const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+        const token = localStorage.getItem('accessToken') || 'null';
         const response = await customAxios.get('/pacers', {
           headers: { Authorization: `${token}` },
         });
@@ -159,7 +159,7 @@ function EventMake() {
       const pad = (n: number) => n.toString().padStart(2, '0');
       const eventDateTime = `${utcDate.getFullYear()}-${pad(utcDate.getMonth() + 1)}-${pad(utcDate.getDate())}T${pad(utcDate.getHours())}:${pad(utcDate.getMinutes())}:${pad(utcDate.getSeconds())}`;
 
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
 
       const formData = new FormData();
       const eventType = isCustom ? customInput : selected;

--- a/src/components/NewEvent/NewEventAdmin.tsx
+++ b/src/components/NewEvent/NewEventAdmin.tsx
@@ -96,7 +96,7 @@ const NewEventAdmin: React.FC<FlashRunUserData> = ({
         await attendanceListRef.current.saveAttendance();
       }
 
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const response = await customAxios.patch(
         `/run/event/post/${postId}/close`,
         {},
@@ -156,7 +156,7 @@ const NewEventAdmin: React.FC<FlashRunUserData> = ({
 
   const handleStartClick = async () => {
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const response = await customAxios.patch(
         `/run/event/post/${postId}/join`,
         {},
@@ -196,7 +196,7 @@ const NewEventAdmin: React.FC<FlashRunUserData> = ({
     }
 
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const response = await customAxios.post(
         `/run/event/post/${postId}/attend`,
         { code },
@@ -224,7 +224,7 @@ const NewEventAdmin: React.FC<FlashRunUserData> = ({
 
   const handleTabChange = async (tab: '소개' | '명단') => {
     setActiveTab(tab);
-    const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+    const token = localStorage.getItem('accessToken') || 'null';
 
     try {
       const response = await customAxios.get(`/run/event/post/${postId}`, {
@@ -283,7 +283,7 @@ const NewEventAdmin: React.FC<FlashRunUserData> = ({
   useEffect(() => {
     const fetchPostData = async () => {
       try {
-        const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+        const token = localStorage.getItem('accessToken') || 'null';
         const response = await customAxios.get(`/run/event/post/${postId}`, {
           headers: { Authorization: `${token}` },
         });
@@ -349,7 +349,7 @@ const NewEventAdmin: React.FC<FlashRunUserData> = ({
 
   const fetchParticipants = async () => {
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const response = await customAxios.get(`/run/event/post/${postId}`, {
         headers: { Authorization: `${token}` },
       });
@@ -383,7 +383,7 @@ const NewEventAdmin: React.FC<FlashRunUserData> = ({
 
   const handleCancelParticipation = async () => {
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const response = await customAxios.patch(
         `/run/event/post/${postId}/join`,
         {},
@@ -468,7 +468,7 @@ const NewEventAdmin: React.FC<FlashRunUserData> = ({
                     if (!confirmCancel) return;
 
                     try {
-                      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+                      const token = localStorage.getItem('accessToken') || 'null';
                       if (!token) {
                         alert('로그인이 필요합니다.');
                         return;
@@ -510,7 +510,7 @@ const NewEventAdmin: React.FC<FlashRunUserData> = ({
                   );
                   if (!ok) return;
                   try {
-                    const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+                    const token = localStorage.getItem('accessToken') || 'null';
                     if (!token) {
                       alert('로그인이 필요합니다.');
                       return;

--- a/src/components/NewEvent/NewEventDetail.tsx
+++ b/src/components/NewEvent/NewEventDetail.tsx
@@ -35,7 +35,7 @@ const NewEventDetail: React.FC = () => {
   useEffect(() => {
     const fetchDetail = async () => {
       try {
-        const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+        const token = localStorage.getItem('accessToken') || 'null';
         const response = await customAxios.get(`/run/event/post/${postId}`, {
           headers: {
             Authorization: `${token}`,

--- a/src/components/NewEvent/NewEventUser.tsx
+++ b/src/components/NewEvent/NewEventUser.tsx
@@ -86,7 +86,7 @@ const NewEventUser: React.FC<FlashRunUserData> = ({
 
   const handleStartClick = async () => {
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const response = await customAxios.patch(
         `/run/event/post/${postId}/join`,
         {},
@@ -122,7 +122,7 @@ const NewEventUser: React.FC<FlashRunUserData> = ({
     }
 
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const response = await customAxios.post(
         `/run/event/post/${postId}/attend`,
         { code },
@@ -150,7 +150,7 @@ const NewEventUser: React.FC<FlashRunUserData> = ({
 
   const handleTabChange = async (tab: '소개' | '명단') => {
     setActiveTab(tab);
-    const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+    const token = localStorage.getItem('accessToken') || 'null';
 
     try {
       const response = await customAxios.get(`/run/event/post/${postId}`, {
@@ -209,7 +209,7 @@ const NewEventUser: React.FC<FlashRunUserData> = ({
   useEffect(() => {
     const fetchPostData = async () => {
       try {
-        const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+        const token = localStorage.getItem('accessToken') || 'null';
         const response = await customAxios.get(`/run/event/post/${postId}`, {
           headers: { Authorization: `${token}` },
         });
@@ -274,7 +274,7 @@ const NewEventUser: React.FC<FlashRunUserData> = ({
 
   const fetchParticipants = async () => {
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const response = await customAxios.get(`/run/event/post/${postId}`, {
         headers: { Authorization: `${token}` },
       });
@@ -308,7 +308,7 @@ const NewEventUser: React.FC<FlashRunUserData> = ({
 
   const handleCancelParticipation = async () => {
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const response = await customAxios.patch(
         `/run/event/post/${postId}/join`,
         {},
@@ -394,7 +394,7 @@ const NewEventUser: React.FC<FlashRunUserData> = ({
                 );
                 if (!ok) return;
                 try {
-                  const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+                  const token = localStorage.getItem('accessToken') || 'null';
                   if (!token) {
                     alert('로그인이 필요합니다.');
                     return;

--- a/src/components/NewRegularRun/NewRegularRunAdmin.tsx
+++ b/src/components/NewRegularRun/NewRegularRunAdmin.tsx
@@ -79,7 +79,7 @@ const NewRegularRunAdmin: React.FC<Props> = ({ postId }) => {
 
   const fetchPostData = async () => {
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const response = await customAxios.get(`/run/regular/post/${postId}`, {
         headers: { Authorization: `${token}` },
       });
@@ -132,7 +132,7 @@ const NewRegularRunAdmin: React.FC<Props> = ({ postId }) => {
   const handleStartClick = async () => {
     if (!code) {
       try {
-        const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+        const token = localStorage.getItem('accessToken') || 'null';
         const response = await customAxios.post(
           `/run/regular/post/${postId}/code`,
           {},
@@ -163,7 +163,7 @@ const NewRegularRunAdmin: React.FC<Props> = ({ postId }) => {
     if (!code) return;
 
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
 
       //수정된 출석 정보가 있다면 먼저 저장
       if (Object.keys(editedAttendance).length > 0) {
@@ -205,7 +205,7 @@ const NewRegularRunAdmin: React.FC<Props> = ({ postId }) => {
 
   const handleTabChange = async (tab: '소개' | '명단') => {
     setActiveTab(tab);
-    const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+    const token = localStorage.getItem('accessToken') || 'null';
 
     try {
       const response = await customAxios.get(`/run/regular/post/${postId}`, {
@@ -242,7 +242,7 @@ const NewRegularRunAdmin: React.FC<Props> = ({ postId }) => {
 
   const fetchParticipantsInfo = async () => {
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const response = await customAxios.get(`/run/regular/post/${postId}`, {
         headers: { Authorization: `${token}` },
       });
@@ -281,7 +281,7 @@ const NewRegularRunAdmin: React.FC<Props> = ({ postId }) => {
   };
 
   const saveAttendanceChanges = async () => {
-    const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+    const token = localStorage.getItem('accessToken') || 'null';
     const payload = Object.entries(editedAttendance).map(([userId, isAttend]) => ({
       userId: Number(userId),
       isAttend,
@@ -451,7 +451,7 @@ const NewRegularRunAdmin: React.FC<Props> = ({ postId }) => {
                       const confirmCancel = window.confirm('정말 게시글을 취소하시겠습니까?');
                       if (!confirmCancel) return;
                       try {
-                        const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+                        const token = localStorage.getItem('accessToken') || 'null';
                         if (!token) {
                           alert('로그인이 필요합니다.');
                           return;
@@ -493,7 +493,7 @@ const NewRegularRunAdmin: React.FC<Props> = ({ postId }) => {
                     );
                     if (!confirmDelete) return;
                     try {
-                      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+                      const token = localStorage.getItem('accessToken') || 'null';
                       if (!token) {
                         alert('로그인이 필요합니다.');
                         return;

--- a/src/components/NewRegularRun/NewRegularRunDetail.tsx
+++ b/src/components/NewRegularRun/NewRegularRunDetail.tsx
@@ -33,7 +33,7 @@ const NewRegularRunDetail: React.FC = () => {
   useEffect(() => {
     const fetchDetail = async () => {
       try {
-        const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+        const token = localStorage.getItem('accessToken') || 'null';
         const response = await customAxios.get(`/run/regular/post/${postId}`, {
           headers: {
             Authorization: `${token}`,

--- a/src/components/NewRegularRun/NewRegularRunEdit.tsx
+++ b/src/components/NewRegularRun/NewRegularRunEdit.tsx
@@ -48,14 +48,14 @@ function NewRegularRunEdit() {
 
   useEffect(() => {
     const fetchPacers = async () => {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const response = await customAxios.get('/pacers', {
         headers: { Authorization: `${token}` },
       });
       if (response.data.isSuccess) setPacers(response.data.result);
     };
     const fetchPostData = async () => {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const res = await customAxios.get(`/run/regular/post/${postId}`, {
         headers: { Authorization: `${token}` },
       });
@@ -237,7 +237,7 @@ function NewRegularRunEdit() {
 
       const pad = (n: number) => n.toString().padStart(2, '0');
       const eventDateTime = `${utcDate.getFullYear()}-${pad(utcDate.getMonth() + 1)}-${pad(utcDate.getDate())}T${pad(utcDate.getHours())}:${pad(utcDate.getMinutes())}:${pad(utcDate.getSeconds())}`;
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const formData = new FormData();
       formData.append('title', title);
       formData.append('location', location);

--- a/src/components/NewRegularRun/NewRegularRunMake.tsx
+++ b/src/components/NewRegularRun/NewRegularRunMake.tsx
@@ -53,7 +53,7 @@ function NewRegularRunMake() {
   useEffect(() => {
     const fetchPacers = async () => {
       try {
-        const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+        const token = localStorage.getItem('accessToken') || 'null';
         const response = await customAxios.get('/pacers', {
           headers: { Authorization: `${token}` },
         });
@@ -232,7 +232,7 @@ function NewRegularRunMake() {
       const pad = (n: number) => n.toString().padStart(2, '0');
       const eventDateTime = `${utcDate.getFullYear()}-${pad(utcDate.getMonth() + 1)}-${pad(utcDate.getDate())}T${pad(utcDate.getHours())}:${pad(utcDate.getMinutes())}:${pad(utcDate.getSeconds())}`;
 
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
 
       const formData = new FormData();
       formData.append('title', title);

--- a/src/components/NewRegularRun/NewRegularRunUser.tsx
+++ b/src/components/NewRegularRun/NewRegularRunUser.tsx
@@ -88,7 +88,7 @@ const NewRegularRunUser: React.FC<FlashRunUserData> = ({ postId }) => {
   useEffect(() => {
     const fetchPostData = async () => {
       try {
-        const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+        const token = localStorage.getItem('accessToken') || 'null';
         const response = await customAxios.get(`/run/regular/post/${postId}`, {
           headers: { Authorization: `${token}` },
         });
@@ -148,7 +148,7 @@ const NewRegularRunUser: React.FC<FlashRunUserData> = ({ postId }) => {
 
   const fetchParticipantsInfo = async () => {
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const response = await customAxios.get(`/run/regular/post/${postId}`, {
         headers: { Authorization: `${token}` },
       });
@@ -189,7 +189,7 @@ const NewRegularRunUser: React.FC<FlashRunUserData> = ({ postId }) => {
   const handleOpenGroupModal = async () => {
     setIsGroupModalOpen(true);
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const res = await customAxios.get(`/run/regular/post/${postId}/group`, {
         headers: { Authorization: `${token}` },
       });
@@ -203,7 +203,7 @@ const NewRegularRunUser: React.FC<FlashRunUserData> = ({ postId }) => {
     const isCancel = selectedGroup === '';
 
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const res = await customAxios.patch(
         `/run/regular/post/${postId}/join${!isCancel ? `?group=${selectedGroup}` : ''}`,
         {},
@@ -242,7 +242,7 @@ const NewRegularRunUser: React.FC<FlashRunUserData> = ({ postId }) => {
   const handleAttendanceClick = async () => {
     if (!code) return setError('출석 코드를 입력해주세요.');
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const response = await customAxios.post(
         `/run/regular/post/${postId}/attend`,
         { code },
@@ -307,7 +307,7 @@ const NewRegularRunUser: React.FC<FlashRunUserData> = ({ postId }) => {
   };
 
   const saveAttendanceChanges = async () => {
-    const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+    const token = localStorage.getItem('accessToken') || 'null';
     const payload = Object.entries(editedAttendance).map(([userId, isAttend]) => ({
       userId: Number(userId),
       isAttend,
@@ -381,7 +381,7 @@ const NewRegularRunUser: React.FC<FlashRunUserData> = ({ postId }) => {
                   if (!confirmDelete) return;
 
                   try {
-                    const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+                    const token = localStorage.getItem('accessToken') || 'null';
                     if (!token) {
                       alert('로그인이 필요합니다.');
                       return;

--- a/src/components/NewTraining/NewTrainingAdmin.tsx
+++ b/src/components/NewTraining/NewTrainingAdmin.tsx
@@ -94,7 +94,7 @@ const NewTrainingAdmin: React.FC<Props> = ({ postId }) => {
   };
 
   const saveAttendanceChanges = async () => {
-    const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+    const token = localStorage.getItem('accessToken') || 'null';
     const payload = Object.entries(editedAttendance).map(([userId, isAttend]) => ({
       userId: Number(userId),
       isAttend,
@@ -115,7 +115,7 @@ const NewTrainingAdmin: React.FC<Props> = ({ postId }) => {
 
   const fetchParticipantsInfo = async () => {
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const response = await customAxios.get(`/run/training/post/${postId}`, {
         headers: { Authorization: `${token}` },
       });
@@ -143,7 +143,7 @@ const NewTrainingAdmin: React.FC<Props> = ({ postId }) => {
   useEffect(() => {
     const fetchPostData = async () => {
       try {
-        const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+        const token = localStorage.getItem('accessToken') || 'null';
         const response = await customAxios.get(`/run/training/post/${postId}`, {
           headers: { Authorization: `${token}` },
         });
@@ -187,7 +187,7 @@ const NewTrainingAdmin: React.FC<Props> = ({ postId }) => {
 
   const handleTabChange = async (tab: '소개' | '명단') => {
     setActiveTab(tab);
-    const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+    const token = localStorage.getItem('accessToken') || 'null';
 
     try {
       const response = await customAxios.get(`/run/training/post/${postId}`, {
@@ -225,7 +225,7 @@ const NewTrainingAdmin: React.FC<Props> = ({ postId }) => {
   const handleStartClick = async () => {
     if (!code) {
       try {
-        const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+        const token = localStorage.getItem('accessToken') || 'null';
         const response = await customAxios.post(
           `/run/training/post/${postId}/code`,
           {},
@@ -256,7 +256,7 @@ const NewTrainingAdmin: React.FC<Props> = ({ postId }) => {
     if (!code) return;
 
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
 
       if (Object.keys(editedAttendance).length > 0) {
         const payload = Object.entries(editedAttendance).map(([userId, isAttend]) => ({
@@ -390,7 +390,7 @@ const NewTrainingAdmin: React.FC<Props> = ({ postId }) => {
 
   const refetchPost = async () => {
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const { data } = await customAxios.get(`/run/training/post/${postId}`, {
         headers: { Authorization: `${token}` },
       });
@@ -497,7 +497,7 @@ const NewTrainingAdmin: React.FC<Props> = ({ postId }) => {
                     if (!confirmCancel) return;
 
                     try {
-                      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+                      const token = localStorage.getItem('accessToken') || 'null';
                       if (!token) {
                         alert('로그인이 필요합니다.');
                         return;
@@ -545,7 +545,7 @@ const NewTrainingAdmin: React.FC<Props> = ({ postId }) => {
                   );
                   if (!ok) return;
                   try {
-                    const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+                    const token = localStorage.getItem('accessToken') || 'null';
                     if (!token) {
                       alert('로그인이 필요합니다.');
                       return;

--- a/src/components/NewTraining/NewTrainingDetail.tsx
+++ b/src/components/NewTraining/NewTrainingDetail.tsx
@@ -33,7 +33,7 @@ const NewTrainingDetail: React.FC = () => {
   useEffect(() => {
     const fetchDetail = async () => {
       try {
-        const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+        const token = localStorage.getItem('accessToken') || 'null';
         const response = await customAxios.get(`/run/training/post/${postId}`, {
           headers: {
             Authorization: `${token}`,

--- a/src/components/NewTraining/NewTrainingEdit.tsx
+++ b/src/components/NewTraining/NewTrainingEdit.tsx
@@ -47,14 +47,14 @@ function NewTrainingEdit() {
 
   useEffect(() => {
     const fetchPacers = async () => {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const response = await customAxios.get('/pacers', {
         headers: { Authorization: `${token}` },
       });
       if (response.data.isSuccess) setPacers(response.data.result);
     };
     const fetchPostData = async () => {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const res = await customAxios.get(`/run/training/post/${postId}`, {
         headers: { Authorization: `${token}` },
       });
@@ -201,7 +201,7 @@ function NewTrainingEdit() {
       const day = pad(dateTime.date!.getDate());
       const time = dateTime.time;
       const eventDateTime = `${year}-${month}-${day}T${time}:00`;
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const formData = new FormData();
       formData.append('title', title);
       formData.append('location', location);

--- a/src/components/NewTraining/NewTrainingUser.tsx
+++ b/src/components/NewTraining/NewTrainingUser.tsx
@@ -104,7 +104,7 @@ const NewTrainingUser: React.FC<FlashRunUserData> = ({ postId }) => {
   };
 
   const saveAttendanceChanges = async () => {
-    const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+    const token = localStorage.getItem('accessToken') || 'null';
     const payload = Object.entries(editedAttendance).map(([userId, isAttend]) => ({
       userId: Number(userId),
       isAttend,
@@ -162,7 +162,7 @@ const NewTrainingUser: React.FC<FlashRunUserData> = ({ postId }) => {
   useEffect(() => {
     const fetchPostData = async () => {
       try {
-        const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+        const token = localStorage.getItem('accessToken') || 'null';
         const response = await customAxios.get(`/run/training/post/${postId}`, {
           headers: { Authorization: `${token}` },
         });
@@ -221,7 +221,7 @@ const NewTrainingUser: React.FC<FlashRunUserData> = ({ postId }) => {
 
   const fetchParticipantsInfo = async () => {
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const response = await customAxios.get(`/run/training/post/${postId}`, {
         headers: { Authorization: `${token}` },
       });
@@ -262,7 +262,7 @@ const NewTrainingUser: React.FC<FlashRunUserData> = ({ postId }) => {
   const handleOpenGroupModal = async () => {
     setIsGroupModalOpen(true);
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const res = await customAxios.get(`/run/training/post/${postId}/group`, {
         headers: { Authorization: `${token}` },
       });
@@ -276,7 +276,7 @@ const NewTrainingUser: React.FC<FlashRunUserData> = ({ postId }) => {
     const isCancel = selectedGroup === '';
 
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const res = await customAxios.patch(
         `/run/training/post/${postId}/join${!isCancel ? `?group=${selectedGroup}` : ''}`,
         {},
@@ -317,7 +317,7 @@ const NewTrainingUser: React.FC<FlashRunUserData> = ({ postId }) => {
 
   const handleStartClick = async () => {
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const response = await customAxios.post(
         `/run/training/post/${postId}/join`,
         {},
@@ -342,7 +342,7 @@ const NewTrainingUser: React.FC<FlashRunUserData> = ({ postId }) => {
   const handleAttendanceClick = async () => {
     if (!code) return setError('출석 코드를 입력해주세요.');
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const response = await customAxios.post(
         `/run/training/post/${postId}/attend`,
         { code },
@@ -369,7 +369,7 @@ const NewTrainingUser: React.FC<FlashRunUserData> = ({ postId }) => {
 
   const handleTabChange = async (tab: '소개' | '명단') => {
     setActiveTab(tab);
-    const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+    const token = localStorage.getItem('accessToken') || 'null';
 
     try {
       const response = await customAxios.get(`/run/training/post/${postId}`, {
@@ -509,7 +509,7 @@ const NewTrainingUser: React.FC<FlashRunUserData> = ({ postId }) => {
                 );
                 if (!ok) return;
                 try {
-                  const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+                  const token = localStorage.getItem('accessToken') || 'null';
                   if (!token) {
                     alert('로그인이 필요합니다.');
                     return;

--- a/src/components/NewTraining/TrainingMake.tsx
+++ b/src/components/NewTraining/TrainingMake.tsx
@@ -126,7 +126,7 @@ function TrainingMake() {
   useEffect(() => {
     const fetchPacers = async () => {
       try {
-        const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+        const token = localStorage.getItem('accessToken') || 'null';
         const response = await customAxios.get('/pacers', {
           headers: { Authorization: `${token}` },
         });
@@ -245,7 +245,7 @@ function TrainingMake() {
       const pad = (n: number) => n.toString().padStart(2, '0');
       const eventDateTime = `${utcDate.getFullYear()}-${pad(utcDate.getMonth() + 1)}-${pad(utcDate.getDate())}T${pad(utcDate.getHours())}:${pad(utcDate.getMinutes())}:${pad(utcDate.getSeconds())}`;
 
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
 
       const formData = new FormData();
       const trainingType = isCustom ? customInput : selected;

--- a/src/components/common/CommentSection.tsx
+++ b/src/components/common/CommentSection.tsx
@@ -60,7 +60,7 @@ const CommentSection: React.FC<CommentSectionProps> = ({
   // 서버에서 댓글 데이터 불러오기
   const fetchComments = async () => {
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const response = await customAxios.get(`/run/${postType}/post/${postId}`, {
         headers: { Authorization: `${token}` },
       });
@@ -77,7 +77,7 @@ const CommentSection: React.FC<CommentSectionProps> = ({
     if (!newComment.trim() || isSubmitting) return;
     setIsSubmitting(true);
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const response = await customAxios.post(
         `/run/${postType}/post/${postId}/comment`,
         { content: newComment, targetId: null },
@@ -100,7 +100,7 @@ const CommentSection: React.FC<CommentSectionProps> = ({
     if (!content?.trim() || isSubmitting) return;
     setIsSubmitting(true);
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const response = await customAxios.post(
         `/run/${postType}/post/${postId}/comment`,
         { content, targetId },
@@ -126,7 +126,7 @@ const CommentSection: React.FC<CommentSectionProps> = ({
   // 댓글 삭제하기
   const handleDeleteComment = async (commentId: number) => {
     try {
-      const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+      const token = localStorage.getItem('accessToken') || 'null';
       const response = await customAxios.patch(
         `/run/${postType}/post/${postId}/comment/${commentId}`,
         {},

--- a/src/features/ranking/components/EventSection.tsx
+++ b/src/features/ranking/components/EventSection.tsx
@@ -35,7 +35,7 @@ export default function EventSection({ onShowDetailModal }: { onShowDetailModal:
 
   // 이벤트에 관한 랭킹 정보를 가지고 오는 메소드 fetchEventRanking
   const fetchEventRanking = async () => {
-    const accessToken = JSON.parse(localStorage.getItem('accessToken') || ''); //localStorage에 저장된 accessToken 값이 없으면 ''으로 초기화
+    const accessToken = localStorage.getItem('accessToken') || ''; //localStorage에 저장된 accessToken 값이 없으면 ''으로 초기화
     const url = '/ranking/event';
 
     try {

--- a/src/features/ranking/components/RankingSection.tsx
+++ b/src/features/ranking/components/RankingSection.tsx
@@ -25,7 +25,7 @@ export default function RankingSection() {
 
   // top20 랭킹 정보를 가져오는 fetchRanking
   const fetchRanking = async () => {
-    const accessToken = JSON.parse(localStorage.getItem('accessToken') || '');
+    const accessToken = localStorage.getItem('accessToken') || '';
 
     try {
       const response = await customAxios.get('/ranking', {

--- a/src/pages/ActivityDetailPage.tsx
+++ b/src/pages/ActivityDetailPage.tsx
@@ -63,7 +63,7 @@ function ActivityDetailPage() {
   async function fetchUserDetailedProfile() {
     try {
       const url = '/user/profile/participations'; //"마이페이지 활동내역 조회" api의 url로 설정
-      const accessToken = JSON.parse(localStorage.getItem('accessToken') || ''); //localStorage에 저장된 accessToken 값이 없으면 ''으로 초기화
+      const accessToken = localStorage.getItem('accessToken') || ''; //localStorage에 저장된 accessToken 값이 없으면 ''으로 초기화
       const response = await customAxios.get(url, {
         headers: {
           Authorization: accessToken,

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -169,7 +169,7 @@ function MyPage() {
 
   //"출석하기" 버튼 클릭 시 이벤트 수행
   async function handleAttendCheckBtn() {
-    const accessToken = JSON.parse(localStorage.getItem('accessToken') || ''); //localStorage에 저장된 accessToken 값이 없으면 ''으로 초기화
+    const accessToken = localStorage.getItem('accessToken') || ''; //localStorage에 저장된 accessToken 값이 없으면 ''으로 초기화
     const url = `/user/attend`;
 
     try {

--- a/src/pages/ProfileFixPage.tsx
+++ b/src/pages/ProfileFixPage.tsx
@@ -152,7 +152,7 @@ function ProfileFixPage() {
     if (password !== '') formData.append('password', password); //비밀번호가 공백이라면, 빈 채로 보내줘야 함
 
     try {
-      const accessToken = JSON.parse(localStorage.getItem('accessToken') || ''); //localStorage에 저장된 accessToken 값이 없으면 ''으로 초기화
+      const accessToken = localStorage.getItem('accessToken') || ''; //localStorage에 저장된 accessToken 값이 없으면 ''으로 초기화
       const url = `/user/profile`;
       const response = await customAxios.patch(url, formData, {
         headers: {
@@ -232,7 +232,7 @@ function ProfileFixPage() {
   async function fetchUserDetailedProfile() {
     try {
       const url = '/user/profile/detail';
-      const accessToken = JSON.parse(localStorage.getItem('accessToken') || ''); //localStorage에 저장된 accessToken 값이 없으면 ''으로 초기화
+      const accessToken = localStorage.getItem('accessToken') || ''; //localStorage에 저장된 accessToken 값이 없으면 ''으로 초기화
       const response = await customAxios.get(url, {
         headers: {
           Authorization: accessToken,

--- a/src/pages/RankingPage.tsx
+++ b/src/pages/RankingPage.tsx
@@ -40,7 +40,7 @@ function RankingPage() {
 
   //초기에 랭킹 정보를 가져와야 한다. 해당 기능을 수행하는 메소드 fetchRankingInfo()
   async function fetchRankingInfo() {
-    const accessToken = JSON.parse(localStorage.getItem('accessToken') || ''); //localStorage에 저장된 accessToken 값이 없으면 ''으로 초기화
+    const accessToken = localStorage.getItem('accessToken') || ''; //localStorage에 저장된 accessToken 값이 없으면 ''으로 초기화
 
     const url = '/ranking';
 

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -73,7 +73,7 @@ function SchedulePage() {
   useEffect(() => {
     const fetchMain = async () => {
       try {
-        const token = JSON.parse(localStorage.getItem('accessToken') || 'null');
+        const token = localStorage.getItem('accessToken') || 'null';
         const response = await customAxios.get(`/run`, {
           headers: { Authorization: `${token}` },
         });
@@ -95,7 +95,7 @@ function SchedulePage() {
   //캘린더 월별 조회 메소드
   async function fetchMonthlyData() {
     const formattedPointDate = format(pointDate, 'yyyy-MM-dd'); //pointDate(기준이 되는 날짜) 포맷팅
-    const accessToken = JSON.parse(localStorage.getItem('accessToken') || ''); //localStorage에 저장된 accessToken 값이 없으면 ''으로 초기화
+    const accessToken = localStorage.getItem('accessToken') || ''; //localStorage에 저장된 accessToken 값이 없으면 ''으로 초기화
 
     //url에 날짜를 'yyyy-MM-dd' 형식으로 담아서 보내야 함
     const url = `/calendar/monthly?date=${formattedPointDate}`;
@@ -132,7 +132,7 @@ function SchedulePage() {
   //캘린더 일별 조회 메소드
   async function fetchSelectedDateEventData() {
     const formattedSelectedDate = format(selectedDate, 'yyyy-MM-dd'); // selectedDate(선택된 날짜) 포맷팅
-    const accessToken = JSON.parse(localStorage.getItem('accessToken') || ''); //localStorage에 저장된 accessToken 값이 없으면 ''으로 초기화
+    const accessToken = localStorage.getItem('accessToken') || ''; //localStorage에 저장된 accessToken 값이 없으면 ''으로 초기화
 
     //url에 날짜를 'yyyy-MM-dd' 형식으로 담아서 보내야 함
     const url = `/calendar/daily?date=${formattedSelectedDate}`;

--- a/src/shared/hooks/useNavBar.ts
+++ b/src/shared/hooks/useNavBar.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState, useMemo } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { tabHistory, setTabHistory } from '../utils/tabHistory';
 
 function useNavBar() {
   const navigate = useNavigate(); //네비게이팅을 위해 useNavigate() 훅 사용
@@ -29,6 +30,22 @@ function useNavBar() {
     navigate(path); //지정한 경로로 이동
   }
 
+  // useNavBar 안의 홈 클릭 처리
+  const handleHomeClick = () => {
+    const currentPath = location.pathname;
+    const lastSavedHomePath = tabHistory.home;
+
+    // 같은 탭에서 두번 클릭
+    if (currentPath === lastSavedHomePath) {
+      setTabHistory('home', '/tab/main');
+      navigate('/tab/main');
+    }
+    // 2. 다른 탭에서 넘어왔을때
+    else {
+      navigate(lastSavedHomePath);
+    }
+  };
+
   // 아이콘을 선택 상태에 따라 동적으로 색깔 적용
   const getIconColor = (tabName: string) =>
     selectedTab === tabName ? 'text-kuDarkGreen' : 'text-gray-400';
@@ -43,6 +60,7 @@ function useNavBar() {
     selectedTab,
     setSelectedTab,
     handleNavigation,
+    handleHomeClick,
     getIconColor,
     getTextColor,
   };

--- a/src/shared/ui/NavBar.tsx
+++ b/src/shared/ui/NavBar.tsx
@@ -7,17 +7,14 @@ import MyPageIcon from '@assets/navi-icon/mypage-icon.svg?react';
 
 // NavBar 컴포넌트
 function NavBar() {
-  const { handleNavigation, getIconColor, getTextColor } = useNavBar();
+  const { handleNavigation, getIconColor, getTextColor, handleHomeClick } = useNavBar();
   return (
     <div className="w-full">
       {/* 네비게이션 바 */}
 
       <nav className="fixed bottom-0 left-1/2 transform -translate-x-1/2 flex justify-between items-center max-w-[430px] w-full h-16 border-t-[1.5px] border-gray-300 bg-white z-[1000]">
         {/* 홈 아이콘 */}
-        <div
-          className="w-1/4 flex flex-col items-center cursor-pointer"
-          onClick={() => handleNavigation('/tab/main', 'main')}
-        >
+        <div className="w-1/4 flex flex-col items-center cursor-pointer" onClick={handleHomeClick}>
           <MainIcon className={`w-6 h-6 ${getIconColor('main')}`} />
           <div className={`text-xs ${getTextColor('main')}`}>홈</div>
         </div>

--- a/src/shared/utils/tabHistory.ts
+++ b/src/shared/utils/tabHistory.ts
@@ -1,0 +1,14 @@
+// Main Tab별 마지막 방문 경로 저장
+
+// 텝 별 마지막 위치 기본 값
+export const tabHistory = {
+  home: '/tab/main',
+  schedule: '/tab/schedule-page',
+  ranking: '/tab/ranking-page',
+  mypage: '/tab/my-page',
+};
+
+// 특정 탭 경로 업데이트
+export const setTabHistory = (tab: keyof typeof tabHistory, path: string) => {
+  tabHistory[tab] = path;
+};


### PR DESCRIPTION
## #️⃣연관된 이슈 (없으면 비워두세요)
#11 
## 📝작업 내용

- 홈 화면 메인 탭의 마지막 방문 페이지를 기억하여, 다른 탭에서 홈 탭으로 왔을때 마지막 방문 페이지를 보여줍니다.
 - 한번 클릭 시 마지막 방문페이지를 보여주고
 - 한번 더 클릭시 홈 페이지로 이동 합니다. (instagram style)

## 📸스크린샷 (선택)

## 💬리뷰 요구사항(선택)

1. MainTab에서 홈 페이지 제외하고는 탭을 누르고 나오는 페이지가 마지막 페이지라 홈  탭 내부의 페이지만 타겟팅하여 저장합니다. 
(라우팅 주소만 저장하면 되고 렌더링과는 관련이 없으므로 전역상태대신 객체를 생성하여 구현했습니다.)

2. 개발서버에서 /regular 까지는 잘 접속이 되는데, 특정 행사 페이지 ex. /regular/456 에 접속 시 accessToken 파싱 오류가 발생하여 로그인 화면으로 튕깁니다. 해결하고 PR 올리려 했으나 시간상 점점 늦어질거같아 PR 먼저 올립니다.

3. (4.29 수) 2번 문제는 accessToken을 localStorage에 String으로 저장하였으나, getItem에서 JSON.parse로 불러와서 생긴 에러였던 것 같습니다. accessToken을 get할때 JSON.parse 로직을 일괄삭제하여 개발 서버에서 정상 접속하는 것을 확인했습니다. 
한번 검토해주시면 감사하겠습니다.

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작함
- [ ] UI/UX가 일관됨
