### PR TITLE
Fix/auth review and header route

### DIFF
--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,10 +1,50 @@
-import React from 'react';
+import { useEffect, useState } from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
+import { getAccessToken, getRefreshToken, reissueToken } from '@features/auth/api/tokenAuth';
 
 //인증 여부를 확인하고 라우팅을 제어하는 보호 Route Component
 const ProtectedRoute = () => {
-  //로그인 여부를 localStorage에 저장된 'accessToken'으로 판단
-  const isAuthenticated = !!localStorage.getItem('accessToken');
+  const [isCheckingAuth, setIsCheckingAuth] = useState(true);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const checkAuth = async () => {
+      if (getAccessToken()) {
+        setIsAuthenticated(true);
+        setIsCheckingAuth(false);
+        return;
+      }
+
+      if (!getRefreshToken()) {
+        setIsAuthenticated(false);
+        setIsCheckingAuth(false);
+        return;
+      }
+
+      const isReissued = await reissueToken();
+
+      if (isMounted) {
+        setIsAuthenticated(isReissued);
+        setIsCheckingAuth(false);
+      }
+    };
+
+    checkAuth();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  if (isCheckingAuth) {
+    return (
+      <div className="min-h-screen flex justify-center items-center bg-white">
+        <span className="text-gray-400 text-sm animate-pulse">로그인 정보를 확인 중입니다...</span>
+      </div>
+    );
+  }
 
   //localStorage에 accessToken이 저장되어 있지 않은 경우, 로그인 페이지로 redirect 시킨다
   if (!isAuthenticated) {

--- a/src/features/auth/api/getIsStudentidValidate.ts
+++ b/src/features/auth/api/getIsStudentidValidate.ts
@@ -1,9 +1,10 @@
 import customAxios from '@shared/lib/customAxios';
+import { AUTH_ENDPOINTS } from '@features/auth/constants';
 
 // 학번 중복 검사 요청하는 api 함수
 async function getIsStudentidValidate(studentID: string) {
   try {
-    const response = await customAxios.get(`/user/check-id?studentId=${studentID}`);
+    const response = await customAxios.get(AUTH_ENDPOINTS.checkStudentId(studentID));
     //중복 확인 검사 성공했을 경우에만 (result 값이 false여야 함)
     if (response.data.result === false) {
       // alert("학번이 유효합니다! 다음 단계로 넘어갑니다.");

--- a/src/features/auth/api/postLogin.ts
+++ b/src/features/auth/api/postLogin.ts
@@ -1,4 +1,5 @@
 import customAxios from '@shared/lib/customAxios';
+import { AUTH_ENDPOINTS } from '@features/auth/constants';
 import { saveAuthResult } from './tokenAuth';
 
 // '로그인' 요청을 보내는 API 함수
@@ -9,7 +10,7 @@ async function postLogin(id: string, password: string) {
     password: password,
   };
 
-  const url = '/user/login'; // URL 설정
+  const url = AUTH_ENDPOINTS.login;
   console.log('data', data);
 
   try {

--- a/src/features/auth/api/postLogin.ts
+++ b/src/features/auth/api/postLogin.ts
@@ -1,4 +1,5 @@
 import customAxios from '@shared/lib/customAxios';
+import { saveAuthResult } from './tokenAuth';
 
 // '로그인' 요청을 보내는 API 함수
 async function postLogin(id: string, password: string) {
@@ -24,8 +25,7 @@ async function postLogin(id: string, password: string) {
     }
 
     // 3. 성공 처리
-    localStorage.setItem('accessToken', result.jwtInfo.accessToken);
-    localStorage.setItem('MyId', result.userId);
+    saveAuthResult(result);
     return true; // 'true'를 반환하여, 로그인 성공 여부를 컴포넌트에서 확인할 수 있도록 함
   } catch (error) {
     // 인터셉터에서 정제된 message를 그대로 사용

--- a/src/features/auth/api/postSignUpRequest.ts
+++ b/src/features/auth/api/postSignUpRequest.ts
@@ -1,4 +1,5 @@
 import customAxios from '@shared/lib/customAxios';
+import { AUTH_ENDPOINTS } from '@features/auth/constants';
 import { SignupData } from '@features/auth/types';
 
 //서버에 회원가입 request 진행(POST 요청)
@@ -6,7 +7,7 @@ const postSignUpRequest = async (data: SignupData) => {
   //해당 구역에 axios 요청을 진행할 것임(서버에 입력된 회원 정보를 저장해야 함)
   try {
     console.log('data가 뭐임?', data);
-    const response = await customAxios.post('/user/signup', data);
+    const response = await customAxios.post(AUTH_ENDPOINTS.signup, data);
     if (response.data.isSuccess === true) {
       // 회원가입 성공
       alert('정상적으로 회원 가입이 완료되었습니다');

--- a/src/features/auth/api/tokenAuth.ts
+++ b/src/features/auth/api/tokenAuth.ts
@@ -1,9 +1,5 @@
 import axios from 'axios';
-
-const ACCESS_TOKEN_KEY = 'accessToken';
-const REFRESH_TOKEN_KEY = 'refreshToken';
-const MY_ID_KEY = 'MyId';
-const STUDENT_ID_KEY = 'studentId';
+import { AUTH_ENDPOINTS, AUTH_STORAGE_KEYS } from '@features/auth/constants';
 
 interface JwtInfo {
   accessToken: string;
@@ -31,28 +27,27 @@ const authAxios = axios.create({
 let reissueTokenPromise: Promise<boolean> | null = null;
 
 export function getAccessToken() {
-  return localStorage.getItem(ACCESS_TOKEN_KEY);
+  return localStorage.getItem(AUTH_STORAGE_KEYS.accessToken);
 }
 
 export function getRefreshToken() {
-  return localStorage.getItem(REFRESH_TOKEN_KEY);
+  return localStorage.getItem(AUTH_STORAGE_KEYS.refreshToken);
 }
 
 export function saveAuthResult(result: AuthResult) {
-  localStorage.setItem(ACCESS_TOKEN_KEY, result.jwtInfo.accessToken);
-  localStorage.setItem(REFRESH_TOKEN_KEY, result.jwtInfo.refreshToken);
-  localStorage.setItem(MY_ID_KEY, String(result.userId));
+  localStorage.setItem(AUTH_STORAGE_KEYS.accessToken, result.jwtInfo.accessToken);
+  localStorage.setItem(AUTH_STORAGE_KEYS.refreshToken, result.jwtInfo.refreshToken);
+  localStorage.setItem(AUTH_STORAGE_KEYS.myId, String(result.userId));
 
   if (result.studentId) {
-    localStorage.setItem(STUDENT_ID_KEY, result.studentId);
+    localStorage.setItem(AUTH_STORAGE_KEYS.studentId, result.studentId);
   }
 }
 
 export function clearAuthStorage() {
-  localStorage.removeItem(ACCESS_TOKEN_KEY);
-  localStorage.removeItem(REFRESH_TOKEN_KEY);
-  localStorage.removeItem(MY_ID_KEY);
-  localStorage.removeItem(STUDENT_ID_KEY);
+  Object.values(AUTH_STORAGE_KEYS).forEach((storageKey) => {
+    localStorage.removeItem(storageKey);
+  });
 }
 
 async function requestReissueToken() {
@@ -64,7 +59,7 @@ async function requestReissueToken() {
   }
 
   try {
-    const response = await authAxios.post<ApiResponse<AuthResult>>('/user/reissue', {
+    const response = await authAxios.post<ApiResponse<AuthResult>>(AUTH_ENDPOINTS.reissue, {
       refreshToken,
     });
 
@@ -96,7 +91,7 @@ export async function logout() {
 
   try {
     if (refreshToken) {
-      await authAxios.post('/user/logout', { refreshToken });
+      await authAxios.post(AUTH_ENDPOINTS.logout, { refreshToken });
     }
   } catch {
     // 서버 로그아웃에 실패해도 현재 브라우저의 인증 정보는 반드시 제거한다.

--- a/src/features/auth/api/tokenAuth.ts
+++ b/src/features/auth/api/tokenAuth.ts
@@ -1,0 +1,94 @@
+import axios from 'axios';
+
+const ACCESS_TOKEN_KEY = 'accessToken';
+const REFRESH_TOKEN_KEY = 'refreshToken';
+const MY_ID_KEY = 'MyId';
+const STUDENT_ID_KEY = 'studentId';
+
+interface JwtInfo {
+  accessToken: string;
+  refreshToken: string;
+}
+
+interface AuthResult {
+  userId: number;
+  studentId?: string;
+  jwtInfo: JwtInfo;
+}
+
+interface ApiResponse<T> {
+  isSuccess: boolean;
+  responseCode: number;
+  responseMessage: string;
+  result: T;
+}
+
+const authAxios = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL,
+  timeout: 30000,
+});
+
+export function getAccessToken() {
+  return localStorage.getItem(ACCESS_TOKEN_KEY);
+}
+
+export function getRefreshToken() {
+  return localStorage.getItem(REFRESH_TOKEN_KEY);
+}
+
+export function saveAuthResult(result: AuthResult) {
+  localStorage.setItem(ACCESS_TOKEN_KEY, result.jwtInfo.accessToken);
+  localStorage.setItem(REFRESH_TOKEN_KEY, result.jwtInfo.refreshToken);
+  localStorage.setItem(MY_ID_KEY, String(result.userId));
+
+  if (result.studentId) {
+    localStorage.setItem(STUDENT_ID_KEY, result.studentId);
+  }
+}
+
+export function clearAuthStorage() {
+  localStorage.removeItem(ACCESS_TOKEN_KEY);
+  localStorage.removeItem(REFRESH_TOKEN_KEY);
+  localStorage.removeItem(MY_ID_KEY);
+  localStorage.removeItem(STUDENT_ID_KEY);
+}
+
+export async function reissueToken() {
+  const refreshToken = getRefreshToken();
+
+  if (!refreshToken) {
+    clearAuthStorage();
+    return false;
+  }
+
+  try {
+    const response = await authAxios.post<ApiResponse<AuthResult>>('/user/reissue', {
+      refreshToken,
+    });
+
+    if (!response.data.isSuccess || !response.data.result?.jwtInfo) {
+      clearAuthStorage();
+      return false;
+    }
+
+    saveAuthResult(response.data.result);
+    return true;
+  } catch {
+    clearAuthStorage();
+    return false;
+  }
+}
+
+export async function logout() {
+  const refreshToken = getRefreshToken();
+
+  try {
+    if (refreshToken) {
+      await authAxios.post('/user/logout', { refreshToken });
+    }
+  } catch {
+    // 서버 로그아웃에 실패해도 현재 브라우저의 인증 정보는 반드시 제거한다.
+  } finally {
+    clearAuthStorage();
+  }
+}

--- a/src/features/auth/api/tokenAuth.ts
+++ b/src/features/auth/api/tokenAuth.ts
@@ -28,6 +28,8 @@ const authAxios = axios.create({
   timeout: 30000,
 });
 
+let reissueTokenPromise: Promise<boolean> | null = null;
+
 export function getAccessToken() {
   return localStorage.getItem(ACCESS_TOKEN_KEY);
 }
@@ -53,7 +55,7 @@ export function clearAuthStorage() {
   localStorage.removeItem(STUDENT_ID_KEY);
 }
 
-export async function reissueToken() {
+async function requestReissueToken() {
   const refreshToken = getRefreshToken();
 
   if (!refreshToken) {
@@ -77,6 +79,16 @@ export async function reissueToken() {
     clearAuthStorage();
     return false;
   }
+}
+
+export function reissueToken() {
+  if (!reissueTokenPromise) {
+    reissueTokenPromise = requestReissueToken().finally(() => {
+      reissueTokenPromise = null;
+    });
+  }
+
+  return reissueTokenPromise;
 }
 
 export async function logout() {

--- a/src/features/auth/constants.ts
+++ b/src/features/auth/constants.ts
@@ -1,0 +1,15 @@
+export const AUTH_STORAGE_KEYS = {
+  accessToken: 'accessToken',
+  refreshToken: 'refreshToken',
+  myId: 'MyId',
+  studentId: 'studentId',
+} as const;
+
+export const AUTH_ENDPOINTS = {
+  login: '/user/login',
+  signup: '/user/signup',
+  checkStudentId: (studentId: string) =>
+    `/user/check-id?studentId=${encodeURIComponent(studentId)}`,
+  reissue: '/user/reissue',
+  logout: '/user/logout',
+} as const;

--- a/src/features/auth/hooks/useLoginPage.ts
+++ b/src/features/auth/hooks/useLoginPage.ts
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import postLogin from '@features/auth/api/postLogin';
+import { getAccessToken, getRefreshToken, reissueToken } from '@features/auth/api/tokenAuth';
 
 // 로그인 페이지 컴포넌트에 대해 비즈니스 로직을 관리하는 훅
 function useLoginPage() {
@@ -8,6 +9,33 @@ function useLoginPage() {
 
   const [id, setID] = useState<string>(''); //ID state
   const [password, setPassword] = useState<string>(''); //비밀번호가 유효한지 확인하기 위한 state
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const autoLogin = async () => {
+      if (getAccessToken()) {
+        navigate('/tab/main', { replace: true });
+        return;
+      }
+
+      if (!getRefreshToken()) {
+        return;
+      }
+
+      const isReissued = await reissueToken();
+
+      if (isMounted && isReissued) {
+        navigate('/tab/main', { replace: true });
+      }
+    };
+
+    autoLogin();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [navigate]);
 
   //로그인 버튼 활성,비활성 관리
   const isLoginBtnValid = () => {

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'; // Link 컴포넌트 import
 import profile_Img from '@assets/default_profile.png'; //이미지 불러오기
 import rightArrow_Icon from '@assets/right_arrow.svg'; //라이쿠 로고 불러오기
 import customAxios from '@/shared/lib/customAxios';
+import { logout } from '@features/auth/api/tokenAuth';
 
 import {
   format,
@@ -192,14 +193,9 @@ function MyPage() {
   }
 
   //"로그아웃" 버튼 클릭 시 이벤트 수행
-  function handleLogout() {
-    //1. 토큰 삭제
-    localStorage.removeItem('accessToken');
-
-    //2. alert창 띄우기 (정상적으로 로그아웃 완료)
+  async function handleLogout() {
+    await logout();
     alert('정상적으로 로그아웃 되었습니다.');
-
-    //3. 로그인 페이지로 이동
     navigate('/');
   }
 

--- a/src/pages/OnboradingPage.tsx
+++ b/src/pages/OnboradingPage.tsx
@@ -1,10 +1,39 @@
 import rikulogo from '@assets/onboarding_logo.svg';
 import { useNavigate } from 'react-router-dom';
 import backgroundVideo from '@assets/onboard_video_no_sound.mp4';
+import { useEffect } from 'react';
+import { getAccessToken, getRefreshToken, reissueToken } from '@features/auth/api/tokenAuth';
 
 // 웹사이트 처음 접속 시 보여지는 "온보딩" 페이지
 function OnbordingPage() {
   const navigate = useNavigate();
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const autoLogin = async () => {
+      if (getAccessToken()) {
+        navigate('/tab/main', { replace: true });
+        return;
+      }
+
+      if (!getRefreshToken()) {
+        return;
+      }
+
+      const isReissued = await reissueToken();
+
+      if (isMounted && isReissued) {
+        navigate('/tab/main', { replace: true });
+      }
+    };
+
+    autoLogin();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [navigate]);
 
   const handleLoginClick = () => {
     navigate('/login');

--- a/src/shared/lib/customAxios.ts
+++ b/src/shared/lib/customAxios.ts
@@ -36,7 +36,7 @@ customAxios.interceptors.response.use(
   (response) => response, // 성공적인 응답은 그대로 반환
   async (error) => {
     let message = '알 수 없는 오류가 발생했습니다.'; // 기본 메시지
-    const originalRequest = error.config as RetryableRequestConfig | undefined;
+    const originalRequest = error.config ? (error.config as RetryableRequestConfig) : null;
 
     if (axios.isCancel(error)) {
       // 요청이 취소된 경우

--- a/src/shared/lib/customAxios.ts
+++ b/src/shared/lib/customAxios.ts
@@ -1,4 +1,5 @@
-import axios, { AxiosInstance } from 'axios';
+import axios, { AxiosInstance, InternalAxiosRequestConfig } from 'axios';
+import { clearAuthStorage, getAccessToken, reissueToken } from '@features/auth/api/tokenAuth';
 
 // 요청 취소 함수(cancelRequest)에서 사용할 인터페이스들
 interface CancelMetadata {
@@ -16,11 +17,26 @@ const customAxios: AxiosInstance = axios.create({
   timeout: 30000, // 기본 타임아웃 설정 (10초), 추후에 오버라이드 가능
 });
 
+interface RetryableRequestConfig extends InternalAxiosRequestConfig {
+  _retry?: boolean;
+}
+
+customAxios.interceptors.request.use((config) => {
+  const accessToken = getAccessToken();
+
+  if (accessToken && !config.headers.Authorization) {
+    config.headers.Authorization = accessToken;
+  }
+
+  return config;
+});
+
 // 응답(Response) 관련 에러 interceptor로 처리 (-> 응답 관련한 오류에 대해서 interceptor가 오류 처리를 "알아서" 해줌")
 customAxios.interceptors.response.use(
   (response) => response, // 성공적인 응답은 그대로 반환
-  (error) => {
+  async (error) => {
     let message = '알 수 없는 오류가 발생했습니다.'; // 기본 메시지
+    const originalRequest = error.config as RetryableRequestConfig | undefined;
 
     if (axios.isCancel(error)) {
       // 요청이 취소된 경우
@@ -30,8 +46,22 @@ customAxios.interceptors.response.use(
       message = '네트워크 오류: 연결을 확인해주세요.';
     } else if (error.response.status === 401) {
       //토큰 만료 라우팅 처리
+      if (originalRequest && !originalRequest._retry) {
+        originalRequest._retry = true;
+        const isReissued = await reissueToken();
+
+        if (isReissued) {
+          const accessToken = getAccessToken();
+          if (accessToken) {
+            originalRequest.headers.Authorization = accessToken;
+          }
+
+          return customAxios(originalRequest);
+        }
+      }
+
       message = '인증이 만료되었습니다. 다시 로그인해주세요.';
-      localStorage.removeItem('accessToken');
+      clearAuthStorage();
       window.location.href = '/';
     } else {
       // 그 외의 서버 응답 에러

--- a/src/shared/ui/ActionBar.tsx
+++ b/src/shared/ui/ActionBar.tsx
@@ -7,7 +7,7 @@ import rikuLogo_picture from '@assets/navi-icon/rikuLogo_picture.svg'; //라이�
 
 const ActionBar: React.FC = () => {
   const navigate = useNavigate();
-  const handleMain = () => navigate('/main');
+  const handleMain = () => navigate('/tab/main');
 
   return (
     <div className="fixed top-0 inset-x-0 mx-auto flex justify-between items-center max-w-[430px] w-full h-[56px] border-t-[1.5px] z-[1000] border-kuDarkGreen bg-kuDarkGreen">

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,2 @@
+/// <reference types="vite/client" />
 /// <reference types="vite-plugin-svgr/client" />


### PR DESCRIPTION
## 📝작업 내용
- Auth 관련 storage key를 AUTH_STORAGE_KEYS 객체로 분리
- Auth API endpoint를 AUTH_ENDPOINTS 객체로 분리
- Axios interceptor의 originalRequest 처리 개선
  - undefined 대신 null로 명시적인 빈 상태 표현
- 헤더 로고 클릭 시 잘못된 /main 경로로 이동하던 문제 수정 /main → /tab/main