### PR TITLE
fix: update auth constants and main header route

### DIFF
--- a/src/features/auth/api/getIsStudentidValidate.ts
+++ b/src/features/auth/api/getIsStudentidValidate.ts
@@ -1,9 +1,10 @@
 import customAxios from '@shared/lib/customAxios';
+import { AUTH_ENDPOINTS } from '@features/auth/constants';
 
 // 학번 중복 검사 요청하는 api 함수
 async function getIsStudentidValidate(studentID: string) {
   try {
-    const response = await customAxios.get(`/user/check-id?studentId=${studentID}`);
+    const response = await customAxios.get(AUTH_ENDPOINTS.checkStudentId(studentID));
     //중복 확인 검사 성공했을 경우에만 (result 값이 false여야 함)
     if (response.data.result === false) {
       // alert("학번이 유효합니다! 다음 단계로 넘어갑니다.");

--- a/src/features/auth/api/postLogin.ts
+++ b/src/features/auth/api/postLogin.ts
@@ -1,4 +1,5 @@
 import customAxios from '@shared/lib/customAxios';
+import { AUTH_ENDPOINTS } from '@features/auth/constants';
 import { saveAuthResult } from './tokenAuth';
 
 // '로그인' 요청을 보내는 API 함수
@@ -9,7 +10,7 @@ async function postLogin(id: string, password: string) {
     password: password,
   };
 
-  const url = '/user/login'; // URL 설정
+  const url = AUTH_ENDPOINTS.login;
   console.log('data', data);
 
   try {

--- a/src/features/auth/api/postSignUpRequest.ts
+++ b/src/features/auth/api/postSignUpRequest.ts
@@ -1,4 +1,5 @@
 import customAxios from '@shared/lib/customAxios';
+import { AUTH_ENDPOINTS } from '@features/auth/constants';
 import { SignupData } from '@features/auth/types';
 
 //서버에 회원가입 request 진행(POST 요청)
@@ -6,7 +7,7 @@ const postSignUpRequest = async (data: SignupData) => {
   //해당 구역에 axios 요청을 진행할 것임(서버에 입력된 회원 정보를 저장해야 함)
   try {
     console.log('data가 뭐임?', data);
-    const response = await customAxios.post('/user/signup', data);
+    const response = await customAxios.post(AUTH_ENDPOINTS.signup, data);
     if (response.data.isSuccess === true) {
       // 회원가입 성공
       alert('정상적으로 회원 가입이 완료되었습니다');

--- a/src/features/auth/api/tokenAuth.ts
+++ b/src/features/auth/api/tokenAuth.ts
@@ -1,9 +1,5 @@
 import axios from 'axios';
-
-const ACCESS_TOKEN_KEY = 'accessToken';
-const REFRESH_TOKEN_KEY = 'refreshToken';
-const MY_ID_KEY = 'MyId';
-const STUDENT_ID_KEY = 'studentId';
+import { AUTH_ENDPOINTS, AUTH_STORAGE_KEYS } from '@features/auth/constants';
 
 interface JwtInfo {
   accessToken: string;
@@ -31,28 +27,27 @@ const authAxios = axios.create({
 let reissueTokenPromise: Promise<boolean> | null = null;
 
 export function getAccessToken() {
-  return localStorage.getItem(ACCESS_TOKEN_KEY);
+  return localStorage.getItem(AUTH_STORAGE_KEYS.accessToken);
 }
 
 export function getRefreshToken() {
-  return localStorage.getItem(REFRESH_TOKEN_KEY);
+  return localStorage.getItem(AUTH_STORAGE_KEYS.refreshToken);
 }
 
 export function saveAuthResult(result: AuthResult) {
-  localStorage.setItem(ACCESS_TOKEN_KEY, result.jwtInfo.accessToken);
-  localStorage.setItem(REFRESH_TOKEN_KEY, result.jwtInfo.refreshToken);
-  localStorage.setItem(MY_ID_KEY, String(result.userId));
+  localStorage.setItem(AUTH_STORAGE_KEYS.accessToken, result.jwtInfo.accessToken);
+  localStorage.setItem(AUTH_STORAGE_KEYS.refreshToken, result.jwtInfo.refreshToken);
+  localStorage.setItem(AUTH_STORAGE_KEYS.myId, String(result.userId));
 
   if (result.studentId) {
-    localStorage.setItem(STUDENT_ID_KEY, result.studentId);
+    localStorage.setItem(AUTH_STORAGE_KEYS.studentId, result.studentId);
   }
 }
 
 export function clearAuthStorage() {
-  localStorage.removeItem(ACCESS_TOKEN_KEY);
-  localStorage.removeItem(REFRESH_TOKEN_KEY);
-  localStorage.removeItem(MY_ID_KEY);
-  localStorage.removeItem(STUDENT_ID_KEY);
+  Object.values(AUTH_STORAGE_KEYS).forEach((storageKey) => {
+    localStorage.removeItem(storageKey);
+  });
 }
 
 async function requestReissueToken() {
@@ -64,7 +59,7 @@ async function requestReissueToken() {
   }
 
   try {
-    const response = await authAxios.post<ApiResponse<AuthResult>>('/user/reissue', {
+    const response = await authAxios.post<ApiResponse<AuthResult>>(AUTH_ENDPOINTS.reissue, {
       refreshToken,
     });
 
@@ -96,7 +91,7 @@ export async function logout() {
 
   try {
     if (refreshToken) {
-      await authAxios.post('/user/logout', { refreshToken });
+      await authAxios.post(AUTH_ENDPOINTS.logout, { refreshToken });
     }
   } catch {
     // 서버 로그아웃에 실패해도 현재 브라우저의 인증 정보는 반드시 제거한다.

--- a/src/features/auth/constants.ts
+++ b/src/features/auth/constants.ts
@@ -1,0 +1,15 @@
+export const AUTH_STORAGE_KEYS = {
+  accessToken: 'accessToken',
+  refreshToken: 'refreshToken',
+  myId: 'MyId',
+  studentId: 'studentId',
+} as const;
+
+export const AUTH_ENDPOINTS = {
+  login: '/user/login',
+  signup: '/user/signup',
+  checkStudentId: (studentId: string) =>
+    `/user/check-id?studentId=${encodeURIComponent(studentId)}`,
+  reissue: '/user/reissue',
+  logout: '/user/logout',
+} as const;

--- a/src/shared/lib/customAxios.ts
+++ b/src/shared/lib/customAxios.ts
@@ -36,7 +36,7 @@ customAxios.interceptors.response.use(
   (response) => response, // 성공적인 응답은 그대로 반환
   async (error) => {
     let message = '알 수 없는 오류가 발생했습니다.'; // 기본 메시지
-    const originalRequest = error.config as RetryableRequestConfig | undefined;
+    const originalRequest = error.config ? (error.config as RetryableRequestConfig) : null;
 
     if (axios.isCancel(error)) {
       // 요청이 취소된 경우

--- a/src/shared/ui/ActionBar.tsx
+++ b/src/shared/ui/ActionBar.tsx
@@ -7,7 +7,7 @@ import rikuLogo_picture from '@assets/navi-icon/rikuLogo_picture.svg'; //라이�
 
 const ActionBar: React.FC = () => {
   const navigate = useNavigate();
-  const handleMain = () => navigate('/main');
+  const handleMain = () => navigate('/tab/main');
 
   return (
     <div className="fixed top-0 inset-x-0 mx-auto flex justify-between items-center max-w-[430px] w-full h-[56px] border-t-[1.5px] z-[1000] border-kuDarkGreen bg-kuDarkGreen">


### PR DESCRIPTION
## 📝작업 내용
- Auth 관련 storage key를 AUTH_STORAGE_KEYS 객체로 분리
- Auth API endpoint를 AUTH_ENDPOINTS 객체로 분리
- Axios interceptor의 originalRequest 처리 개선
  - undefined 대신 null로 명시적인 빈 상태 표현
- 헤더 로고 클릭 시 잘못된 /main 경로로 이동하던 문제 수정 /main → /tab/main
